### PR TITLE
Disable gliding when starting to fly in Creative Mode

### DIFF
--- a/dreamvisitor/src/main/java/io/github/stonley890/dreamvisitor/listeners/ListenPlayerToggleFlightEvent.java
+++ b/dreamvisitor/src/main/java/io/github/stonley890/dreamvisitor/listeners/ListenPlayerToggleFlightEvent.java
@@ -47,6 +47,7 @@ public class ListenPlayerToggleFlightEvent implements Listener {
             if (event.isFlying()) {
                 player.setFlySpeed(0.1f);
                 player.setFlying(true);
+                player.setGliding(false);
             } else {
                 player.setFlying(false);
             }


### PR DESCRIPTION
This pull request fixes an issue where toggling flight in Creative Mode did not disable glide mode.